### PR TITLE
Fixes #20, add unit test for getSessionResultsForUser

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -615,7 +615,7 @@ public final class FeedbackSessionsLogic {
         for (FeedbackResponseAttributes response : allResponses) {
             FeedbackQuestionAttributes correspondingQuestion = allQuestionsMap.get(response.feedbackQuestionId);
             if (correspondingQuestion == null) {
-                list.set(15, true); //TODO: Set the value in allQuestionsMap to null for questionId-key
+                list.set(15, true); 
                 // orphan response without corresponding question, ignore it
                 continue;
             } else {

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -535,7 +535,7 @@ public final class FeedbackSessionsLogic {
             list.set(2, true);
             FeedbackQuestionAttributes fqa = fqLogic.getFeedbackQuestion(questionId);
             if (fqa == null) {
-                list.set(3, true); //TODO: Set questionID to null.
+                list.set(3, true);
                 allQuestions = Collections.emptyList();
             } else {
                 list.set(4, true);

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -944,6 +944,28 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     }
 
     @Test
+    public void testGetSessionResultsForUser_studentSpecificQuestion_incorrectQuestionId_shouldGenerateEmptyLists() {
+        dataBundle = getTypicalDataBundle();
+        removeAndRestoreDataBundle(dataBundle);
+        //A questionId that does not exist in the database
+        String questionId = "notActuallyAnExistingQuestionId";
+
+        StudentAttributes student = dataBundle.students.get("student1InCourse1");
+        FeedbackQuestionAttributes question = getQuestionFromDatastore("qn3InSession1InCourse1");
+        SessionResultsBundle bundle = fsLogic.getSessionResultsForUser(
+                question.getFeedbackSessionName(), question.getCourseId(), student.getEmail(),
+                UserRole.STUDENT, questionId, null);
+        //The questionId does not exist in the database, so there should be no related questions, responses or comments.
+        assertEquals(0, bundle.getQuestionsMap().size());
+        assertEquals(0, bundle.getQuestionResponseMap().size());
+        assertEquals(0, bundle.getQuestionMissingResponseMap().size());
+        assertEquals(0, bundle.getResponseCommentsMap().size());
+
+    }
+
+
+
+    @Test
     public void testGetSessionResultsForUser_studentAllQuestions_shouldGenerateCorrectBundle() {
         DataBundle responseBundle = loadDataBundle("/FeedbackSessionResultsTest.json");
         removeAndRestoreDataBundle(responseBundle);


### PR DESCRIPTION
Fixes #20. Adds a unit test for the case when the supplied Question ID does not exist in the database.